### PR TITLE
Add separate command argument to encode HTML entities

### DIFF
--- a/Menus/Context.sublime-menu
+++ b/Menus/Context.sublime-menu
@@ -1,6 +1,19 @@
 [
     {
         "id": "super_awesome_paste",
-        "command": "super_awesome_paste"
+        "caption": "Super-Awesome Paste",
+        "children": [
+            {
+                "caption": "Paste",
+                "command": "super_awesome_paste"
+            },
+            {
+                "caption": "Paste and HTML encode",
+                "command": "super_awesome_paste",
+                "args": {
+                    "html_encode": true
+                }
+            }
+        ]
     }
 ]

--- a/README.md
+++ b/README.md
@@ -12,18 +12,12 @@ These options can be appended to your `Settings - User` file and are prefixed wi
 
 ```json
 {
-    "super_awesome_paste.escape_html": true
+    "super_awesome_paste.format_hex_colors": "uppercase"
 }
 ```
 
-**escape_html**  
-Type: `Boolean`  
-Default: `true`
-
-Convert certain special characters to their escaped HTML entities when pasted into a content tag within an HTML page.
-
-**format_hex_colors**  
-Type: `String`  
+**format_hex_colors**
+Type: `String`
 Default: `"lowercase"`
 
 Specify preferred capitalisation for pasted hex colours - `"lowercase"` or `"uppercase"`. Set `false` to disable.

--- a/commands.py
+++ b/commands.py
@@ -1,35 +1,10 @@
-"""
-Intelligent paste handling for Sublime
-
-Copyright (c) 2014 Alex Hunt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-"""
-
 import sublime
 import sublime_plugin
 from .util import FileInfo, Preferences
 from .paste import Paste
 
 class SuperAwesomePasteCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
+    def run(self, edit, **args):
         # Get current file context
         file = FileInfo(self.view)
         # Get user preferences
@@ -45,11 +20,11 @@ class SuperAwesomePasteCommand(sublime_plugin.TextCommand):
             paste.clean_formatting()
             paste.markdown_formatting()
 
-            if preferences.get_option('escape_html'):
-                paste.html_escape()
-
             if preferences.get_option('format_hex_colors'):
                 paste.format_hex_colors()
+
+            if 'html_encode' in args:
+                paste.html_encode()
 
             paste.apply_line_endings()
 

--- a/paste.py
+++ b/paste.py
@@ -81,12 +81,8 @@ class Paste:
             # If the file content precedes with a quote, merge lines separated by semicolons
             self.text = re.sub(r';\n[ \t]*(\w)', r'; \1', self.text)
 
-    def html_escape(self):
-        if re.search(RegexPatterns.html_opening_content_tag, self.file.get_contents_before()):
-            # If there are no tags or existing escaped entities present in the paste content,
-            # replace special characters with their HTML entity
-            if not re.search(r'[<>]|&[^\s]+;', self.text):
-                self.text = html.escape(self.text)
+    def html_encode(self):
+        self.text = html.escape(self.text)
 
     def format_hex_colors(self):
         if re.match(RegexPatterns.hex_color, self.text):


### PR DESCRIPTION
- This is no longer attempted on each regular paste.
- Passing `{"html_encode": true}` as args will now encode all special characters into escaped HTML entities without previous checks.
- The option `escape_html` has been removed.

Fixes #1 
